### PR TITLE
[codex] Fix done completion move

### DIFF
--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -206,7 +206,7 @@ export class Supervisor {
       const targetColumnName = action.slice(5)
       try {
         const columns = await this.client.listColumns(card.board.id)
-        const target = columns.find(c => c.name.toLowerCase() === targetColumnName.toLowerCase())
+        const target = resolveCompletionColumn(columns, targetColumnName)
         if (target) {
           await this.client.triageCard(card.number, target.id)
           return `comment posted, moved to ${target.name}`
@@ -231,4 +231,23 @@ function escapeHtml(str: string): string {
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
+}
+
+type CompletionColumn = { id: string; name: string }
+
+const PSEUDO_COMPLETION_COLUMNS: Record<string, CompletionColumn> = {
+  "done": { id: "done", name: "Done" },
+}
+
+function resolveCompletionColumn(columns: CompletionColumn[], targetColumnName: string): CompletionColumn | null {
+  const target = normalizeColumnTarget(targetColumnName)
+  const realColumn = columns.find(column =>
+    normalizeColumnTarget(column.name) === target ||
+    normalizeColumnTarget(column.id) === target
+  )
+  return realColumn ?? PSEUDO_COMPLETION_COLUMNS[target] ?? null
+}
+
+function normalizeColumnTarget(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, " ")
 }

--- a/test/supervisor.test.ts
+++ b/test/supervisor.test.ts
@@ -263,6 +263,19 @@ describe("Supervisor", () => {
       expect(client.listColumns).toHaveBeenCalledWith("board-1")
       expect(client.triageCard).toHaveBeenCalledWith(42, "col-done")
     })
+
+    it("triages card to the built-in Done pseudo column", async () => {
+      ;(client.listColumns as ReturnType<typeof vi.fn>).mockResolvedValue([
+        makeColumn({ id: "col-ready", name: "Ready for Agents" }),
+      ])
+      const card = makeCard({ number: 42 })
+      const ticket = makeGoldenTicket({ on_complete: "move:done" })
+
+      await supervisor.spawn(card, ticket)
+      await new Promise(r => setTimeout(r, 100))
+
+      expect(client.triageCard).toHaveBeenCalledWith(42, "done")
+    })
   })
 
   describe("error handling", () => {


### PR DESCRIPTION
## Summary

Fix `#move-to-done` completion handling when Fizzy exposes `Done` as the built-in pseudo column instead of a regular board column.

## Root Cause

Golden tickets parse `#move-to-done` as `move:done`, but `Supervisor.executeOnComplete` only searched the real columns returned by `listColumns()`. On self-hosted Fizzy, the CLI shows `Done` as pseudo column id `done`, while the board columns endpoint used by fizzy-popper only returns regular columns. The move was skipped, leaving the card in the agent-enabled column so reconciliation could run it again.

## Changes

- Resolve completion targets by normalized real column name or id.
- Fall back to the built-in `done` pseudo column for `move:done`.
- Add a supervisor regression test proving `move:done` calls `triageCard(..., "done")` even when `Done` is absent from `listColumns()`.

## Validation

- `npm test` passes: 191 tests.
- `npm run typecheck` passes.
